### PR TITLE
Add OpenPaths provider

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,7 @@ const TOML_CONFIG_PATH = AUTOHAND_FILES.configToml;
 const YAML_CONFIG_PATH = AUTOHAND_FILES.configYaml;
 const YML_CONFIG_PATH = AUTOHAND_FILES.configYml;
 const DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
+const DEFAULT_OPENPATHS_URL = "https://openpaths.io/v1";
 const DEFAULT_OLLAMA_URL = "http://localhost:11434";
 const DEFAULT_LLAMACPP_URL = "http://localhost:8080";
 const DEFAULT_OPENAI_URL = "https://api.openai.com/v1";
@@ -62,6 +63,7 @@ function normalizeProviderName(provider: unknown): ProviderName | undefined {
 
   const validProviders: readonly ProviderName[] = [
     "openrouter",
+    "openpaths",
     "ollama",
     "llamacpp",
     "openai",
@@ -646,6 +648,7 @@ function isModernConfig(
 ): config is AutohandConfig {
   return (
     typeof (config as AutohandConfig).openrouter === "object" ||
+    typeof (config as AutohandConfig).openpaths === "object" ||
     typeof (config as AutohandConfig).ollama === "object" ||
     typeof (config as AutohandConfig).llamacpp === "object" ||
     typeof (config as AutohandConfig).openai === "object" ||
@@ -829,6 +832,7 @@ export function getProviderConfig(
 
   const configByProvider: Record<ProviderName, ProviderSettings | undefined> = {
     openrouter: config.openrouter,
+    openpaths: config.openpaths,
     ollama: config.ollama,
     llamacpp: config.llamacpp,
     openai: config.openai,
@@ -870,6 +874,7 @@ export function getProviderConfig(
     }
   } else if (
     chosen === "openrouter" ||
+    chosen === "openpaths" ||
     chosen === "llmgateway" ||
     chosen === "zai" ||
     chosen === "nvidia" ||
@@ -912,6 +917,7 @@ function defaultBaseUrlFor(
   port?: number,
 ): string | undefined {
   if (provider === "openrouter") return DEFAULT_BASE_URL;
+  if (provider === "openpaths") return DEFAULT_OPENPATHS_URL;
   if (provider === "llmgateway") return DEFAULT_LLMGATEWAY_URL;
   if (provider === "zai") return DEFAULT_ZAI_URL;
   if (provider === "deepseek") return DEFAULT_DEEPSEEK_URL;

--- a/src/core/agent/ProviderConfigManager.ts
+++ b/src/core/agent/ProviderConfigManager.ts
@@ -2810,6 +2810,9 @@ export class ProviderConfigManager {
       openrouter:
         this.runtime.config.openrouter ??
         (this.runtime.config.openrouter = { apiKey: "", model }),
+      openpaths:
+        this.runtime.config.openpaths ??
+        (this.runtime.config.openpaths = { apiKey: "", model }),
       ollama:
         this.runtime.config.ollama ?? (this.runtime.config.ollama = { model }),
       llamacpp:

--- a/src/onboarding/setupWizard.ts
+++ b/src/onboarding/setupWizard.ts
@@ -2051,6 +2051,7 @@ export class SetupWizard {
   private getDefaultModel(provider: ProviderName): string {
     const defaults: Record<ProviderName, string> = {
       openrouter: 'nvidia/nemotron-3-super-120b-a12b:free',
+      openpaths: 'openpaths/auto',
       openai: 'gpt-5.4',
       ollama: 'llama3.2:latest',
       llamacpp: 'local',
@@ -2071,6 +2072,7 @@ export class SetupWizard {
   private getDefaultBaseUrl(provider: ProviderName): string {
     const urls: Record<ProviderName, string> = {
       openrouter: 'https://openrouter.ai/api/v1',
+      openpaths: 'https://openpaths.io/v1',
       openai: 'https://api.openai.com/v1',
       ollama: 'http://localhost:11434',
       llamacpp: 'http://localhost:8080',

--- a/src/providers/OpenPathsProvider.ts
+++ b/src/providers/OpenPathsProvider.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 Autohand AI LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { OpenRouterClient } from "./OpenRouterClient.js";
+import type { LLMProvider } from "./LLMProvider.js";
+import type {
+  LLMRequest,
+  LLMResponse,
+  OpenPathsSettings,
+  NetworkSettings,
+} from "../types.js";
+
+const OPENPATHS_BASE_URL = "https://openpaths.io/v1";
+const OPENPATHS_MODELS_URL = "https://openpaths.io/v1/models";
+
+/**
+ * OpenPaths is an OpenAI-compatible model gateway (https://openpaths.io).
+ * It reuses the generic OpenAI-compatible client used by OpenRouter, pointed
+ * at the OpenPaths base URL.
+ */
+export class OpenPathsProvider implements LLMProvider {
+  private client: OpenRouterClient;
+  private model: string;
+
+  constructor(config: OpenPathsSettings, networkSettings?: NetworkSettings) {
+    this.client = new OpenRouterClient(
+      { ...config, baseUrl: config.baseUrl ?? OPENPATHS_BASE_URL },
+      networkSettings,
+    );
+    this.model = config.model;
+  }
+
+  getName(): string {
+    return "openpaths";
+  }
+
+  setModel(model: string): void {
+    this.model = model;
+    this.client.setDefaultModel(model);
+  }
+
+  async listModels(): Promise<string[]> {
+    try {
+      const response = await fetch(OPENPATHS_MODELS_URL, {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        signal: AbortSignal.timeout(10000),
+      });
+
+      if (response.ok) {
+        const data = (await response.json()) as { data?: Array<{ id?: string }> };
+        const ids = (Array.isArray(data?.data) ? data.data : [])
+          .map((model) => model.id)
+          .filter((id): id is string => Boolean(id));
+
+        if (ids.length > 0) {
+          return ids;
+        }
+      }
+    } catch {
+      // Fall through to the static fallback list below.
+    }
+
+    return [
+      "openpaths/auto",
+      "openpaths/auto-code",
+      "openpaths/auto-fast",
+      "openpaths/auto-reasoning",
+    ];
+  }
+
+  async isAvailable(): Promise<boolean> {
+    // For OpenPaths, we can't easily check without making a request
+    // Return true if we have an API key
+    return true;
+  }
+
+  async complete(request: LLMRequest): Promise<LLMResponse> {
+    return this.client.complete(request);
+  }
+}

--- a/src/providers/ProviderFactory.ts
+++ b/src/providers/ProviderFactory.ts
@@ -10,6 +10,7 @@ import { OllamaProvider } from './OllamaProvider.js';
 import { OpenAIProvider } from './OpenAIProvider.js';
 import { LlamaCppProvider } from './LlamaCppProvider.js';
 import { OpenRouterProvider } from './OpenRouterProvider.js';
+import { OpenPathsProvider } from './OpenPathsProvider.js';
 import { MLXProvider } from './MLXProvider.js';
 import { LLMGatewayProvider } from './LLMGatewayProvider.js';
 import { AzureProvider } from './AzureProvider.js';
@@ -154,6 +155,12 @@ export class ProviderFactory {
                 }
                 return new BedrockProvider(config.bedrock);
 
+            case 'openpaths':
+                if (!config.openpaths) {
+                    return new UnconfiguredProvider('openpaths');
+                }
+                return new OpenPathsProvider(config.openpaths, config.network);
+
             case 'openrouter':
             default:
                 if (!config.openrouter) {
@@ -169,7 +176,7 @@ export class ProviderFactory {
      */
     static getProviderNames(config?: Pick<AutohandConfig, 'features'> | null): ProviderName[] {
         // Sorted DESC by display name: Z.ai, xAI, Vertex AI, NVIDIA, OpenRouter, OpenAI, Ollama, MLX, LLM Gateway, llama.cpp, DeepSeek, Cerebras, Bedrock, Azure
-        const providers: ProviderName[] = ['zai', 'xai', 'vertexai', 'nvidia', 'openrouter', 'openai', 'ollama', 'llmgateway', 'llamacpp', 'deepseek', 'cerebras', 'azure'];
+        const providers: ProviderName[] = ['zai', 'xai', 'vertexai', 'nvidia', 'openrouter', 'openpaths', 'openai', 'ollama', 'llmgateway', 'llamacpp', 'deepseek', 'cerebras', 'azure'];
         if (isAwsBedrockProviderEnabled(config)) {
             providers.splice(providers.indexOf('azure'), 0, 'bedrock');
         }
@@ -189,7 +196,7 @@ export class ProviderFactory {
             return false;
         }
 
-        const allProviders: ProviderName[] = ['openrouter', 'ollama', 'openai', 'llamacpp', 'mlx', 'llmgateway', 'azure', 'zai', 'vertexai', 'xai', 'cerebras', 'nvidia', 'deepseek', 'bedrock'];
+        const allProviders: ProviderName[] = ['openrouter', 'openpaths', 'ollama', 'openai', 'llamacpp', 'mlx', 'llmgateway', 'azure', 'zai', 'vertexai', 'xai', 'cerebras', 'nvidia', 'deepseek', 'bedrock'];
         return allProviders.includes(name as ProviderName);
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ type Primitive = string | number | boolean | null;
 
 export type MessageRole = 'system' | 'user' | 'assistant' | 'tool';
 
-export type ProviderName = 'openrouter' | 'ollama' | 'llamacpp' | 'openai' | 'mlx' | 'llmgateway' | 'azure' | 'zai' | 'vertexai' | 'xai' | 'cerebras' | 'nvidia' | 'deepseek' | 'bedrock';
+export type ProviderName = 'openrouter' | 'openpaths' | 'ollama' | 'llamacpp' | 'openai' | 'mlx' | 'llmgateway' | 'azure' | 'zai' | 'vertexai' | 'xai' | 'cerebras' | 'nvidia' | 'deepseek' | 'bedrock';
 
 export type AzureAuthMethod = 'api-key' | 'entra-id' | 'managed-identity';
 export type OpenAIAuthMode = 'api-key' | 'chatgpt';
@@ -53,6 +53,10 @@ export interface ProviderSettings {
 }
 
 export interface OpenRouterSettings extends ProviderSettings {
+  apiKey: string;
+}
+
+export interface OpenPathsSettings extends ProviderSettings {
   apiKey: string;
 }
 
@@ -650,6 +654,7 @@ export interface ChromeConfigSettings {
 export interface AutohandConfig {
   provider?: ProviderName;
   openrouter?: OpenRouterSettings;
+  openpaths?: OpenPathsSettings;
   ollama?: ProviderSettings;
   llamacpp?: ProviderSettings;
   openai?: OpenAISettings;

--- a/tests/providers/ProviderFactory.test.ts
+++ b/tests/providers/ProviderFactory.test.ts
@@ -52,6 +52,7 @@ describe("ProviderFactory", () => {
         "vertexai",
         "nvidia",
         "openrouter",
+        "openpaths",
         "openai",
         "ollama",
         "llmgateway",
@@ -194,11 +195,39 @@ describe("ProviderFactory", () => {
 
       expect(provider.getName()).toBe("openrouter");
     });
+
+    it("should create OpenPathsProvider when openpaths is configured", () => {
+      const config: AutohandConfig = {
+        provider: "openpaths",
+        openpaths: {
+          apiKey: "test-key",
+          model: "openpaths/auto",
+        },
+      };
+
+      const provider = ProviderFactory.create(config);
+
+      expect(provider.getName()).toBe("openpaths");
+    });
+
+    it("should return UnconfiguredProvider when openpaths config is missing", () => {
+      const config: AutohandConfig = {
+        provider: "openpaths",
+      };
+
+      const provider = ProviderFactory.create(config);
+
+      expect(provider.getName()).toBe("unconfigured");
+    });
   });
 
   describe("isValidProvider()", () => {
     it("should return true for openrouter", () => {
       expect(ProviderFactory.isValidProvider("openrouter")).toBe(true);
+    });
+
+    it("should return true for openpaths", () => {
+      expect(ProviderFactory.isValidProvider("openpaths")).toBe(true);
     });
 
     it("should return true for ollama", () => {


### PR DESCRIPTION
## What

Adds [OpenPaths](https://openpaths.io) as a first-class named provider. OpenPaths is an OpenAI-compatible model gateway (like OpenRouter), so it slots into the existing provider architecture and reuses the generic OpenAI-compatible client.

- Base URL: `https://openpaths.io/v1`
- Models endpoint: `https://openpaths.io/v1/models`
- Default model: `openpaths/auto` (also `openpaths/auto-code`, `-fast`, `-reasoning`)
- API key: `OPENPATHS_API_KEY` (key page: https://openpaths.io/account)

## Changes

Additive and minimal — mirrors the OpenRouter wiring exactly across every parallel provider list.

- `src/types.ts`: add `'openpaths'` to `ProviderName`, add `OpenPathsSettings`, add `openpaths?` to `AutohandConfig`.
- `src/providers/OpenPathsProvider.ts`: new provider (reuses the generic OpenAI-compatible client at the OpenPaths base URL; lists models from `/v1/models` with a static fallback).
- `src/providers/ProviderFactory.ts`: `case 'openpaths'` + entries in `getProviderNames()` / `isValidProvider()`.
- `src/config.ts`: `validProviders`, `isModernConfig`, `getProviderConfig` (Record + api-key validation branch), `defaultBaseUrlFor`.
- `src/onboarding/setupWizard.ts` & `src/core/agent/ProviderConfigManager.ts`: add `openpaths` entries to the exhaustive `Record<ProviderName, ...>` maps (required to keep typecheck green).
- `tests/providers/ProviderFactory.test.ts`: coverage for `openpaths` (create configured / unconfigured, `isValidProvider`, updated `getProviderNames` ordering).

## Testing

- `tsc --noEmit` (typecheck): passes.
- `eslint` on changed files: passes, no warnings.
- `vitest` ProviderFactory + config suites: 41 passed.

Note: I've reviewed CONTRIBUTING.md and COMMERCIAL.md — there's no CLA/DCO requirement and the changes are additive under Apache-2.0. If you do require a contributor agreement, I'm happy to sign your CLA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)