### PR TITLE
Refresh Bedrock and fff runtime dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,10 +6,10 @@
       "name": "autohand-cli",
       "dependencies": {
         "@agentclientprotocol/sdk": "1.3.0",
-        "@aws-sdk/client-bedrock": "^3.1097.0",
+        "@aws-sdk/client-bedrock": "^3.1106.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1086.0",
         "@aws-sdk/credential-providers": "^3.1090.0",
-        "@ff-labs/fff-bun": "0.10.1",
+        "@ff-labs/fff-bun": "0.10.3",
         "chalk": "^5.6.2",
         "commander": "^15.0.0",
         "diff": "^9.0.0",
@@ -191,25 +191,25 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
 
-    "@ff-labs/fff-bin-android-arm64": ["@ff-labs/fff-bin-android-arm64@0.10.1", "", { "os": "android", "cpu": "arm64" }, "sha512-6Bsaa6yKEd2HV1M2WtqSYhoZucKYffIUms6GYoPN48QHP8hZgO8GXJ85/JDxKlkCJsN2hw1ROiwQK0+xUHYhFQ=="],
+    "@ff-labs/fff-bin-android-arm64": ["@ff-labs/fff-bin-android-arm64@0.10.3", "", { "os": "android", "cpu": "arm64" }, "sha512-g9MNo+rNKggdXWehd0H1fMBLnjkO2pvW6Lo3eyGCEEjms4Al1PKOTIeVju7ovrUqLjqQlyhsvUaZECkMzydvKQ=="],
 
-    "@ff-labs/fff-bin-darwin-arm64": ["@ff-labs/fff-bin-darwin-arm64@0.10.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7yUP+56sG3UTrLg7eepOD16yM2dgiD7g6Ase2XWQB7oXwLV7mBMylPKIli2pP3kHzfw9K+BS3WAwHKHJ2QhxYw=="],
+    "@ff-labs/fff-bin-darwin-arm64": ["@ff-labs/fff-bin-darwin-arm64@0.10.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vMn3N39B+AJsjc24jvYsLvrc5VPo4ztSieeSjBkOYgQaG6coaVpSKPcgipJqPdv8VNLzLXd8j9O6FNP3e7HLrw=="],
 
-    "@ff-labs/fff-bin-darwin-x64": ["@ff-labs/fff-bin-darwin-x64@0.10.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-9zb+P1xtyqu/jVklm5RKF2zm9doRRsBNbkF/a8S4aSqSJoNlQR8ZF7C129fzOLfffVAjjgcO2l8oJgxOzHYiwQ=="],
+    "@ff-labs/fff-bin-darwin-x64": ["@ff-labs/fff-bin-darwin-x64@0.10.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-w2X8VmqjEWASmM5LgoytBUtuJTfnZQycpFE67MytfH+57mIO4SJ7cyxvdXw/LRCMIJOToh2A9hJGrEYSLPLa5Q=="],
 
-    "@ff-labs/fff-bin-linux-arm64-gnu": ["@ff-labs/fff-bin-linux-arm64-gnu@0.10.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-KTwr9CUfCJv0vtG2xG+nMxDae/2NJY2/oVmtgSvTnH9baI6JprqsFGphbukx7mdW/QMPwBiYtoO8ZGoC7i92jA=="],
+    "@ff-labs/fff-bin-linux-arm64-gnu": ["@ff-labs/fff-bin-linux-arm64-gnu@0.10.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-3MsSDY3GHLpA+RygqXs6lMeRRn5NfnhWNf/hWLGK/tmczPdQoMEjH25MhVk0HoCMOgrCP86jsBzF8QD9xgdglQ=="],
 
-    "@ff-labs/fff-bin-linux-arm64-musl": ["@ff-labs/fff-bin-linux-arm64-musl@0.10.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-oznmSpV+zjiAPiwqbA4y+SAsMaYvDhGllHiT9L4ebdQnSOfcQzlUwvo45OhBPwHBt47tIois4bkF/MITlDk54A=="],
+    "@ff-labs/fff-bin-linux-arm64-musl": ["@ff-labs/fff-bin-linux-arm64-musl@0.10.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-96FYchBgdHBmPPW9w4Q8mUhGTjw59ZQQEI2XZViPGfRm2DVA8Br9Npp3XX45Rw6d9G3cDZcWabr/eqvJY8vrrg=="],
 
-    "@ff-labs/fff-bin-linux-x64-gnu": ["@ff-labs/fff-bin-linux-x64-gnu@0.10.1", "", { "os": "linux", "cpu": "x64" }, "sha512-KDpl8lwSEOauP/6FSJIvnARzE+ILm2rVIRQAio9dc5nn56EvlsryBWry0c5V0Tbw1PV0lNrZ+bzcIiPuTacvzw=="],
+    "@ff-labs/fff-bin-linux-x64-gnu": ["@ff-labs/fff-bin-linux-x64-gnu@0.10.3", "", { "os": "linux", "cpu": "x64" }, "sha512-F1H0tP92FbaJfVzm79ptvHmR21QggNw+tQXUxq77HfKlnBLoT944pWH5MHaKGoz4pkF1Vg/hh0ROUaBTvF9Rmw=="],
 
-    "@ff-labs/fff-bin-linux-x64-musl": ["@ff-labs/fff-bin-linux-x64-musl@0.10.1", "", { "os": "linux", "cpu": "x64" }, "sha512-mZCpojVtGNDr/wdCUEAHdfrl6qORvKHv3Pw35TaOdshnG4wocoA5bBKTGj/zmAU11o0GMK4V+wUhdNrgqoE10w=="],
+    "@ff-labs/fff-bin-linux-x64-musl": ["@ff-labs/fff-bin-linux-x64-musl@0.10.3", "", { "os": "linux", "cpu": "x64" }, "sha512-p9mIROa2iEvO5HV5gNLuYr2EkQTnCeaztVnWZbDjQiQE5tTx2tUUVDzQUQutHVvtNKlsrZWoqCJ/G6xbFqWCSw=="],
 
-    "@ff-labs/fff-bin-win32-arm64": ["@ff-labs/fff-bin-win32-arm64@0.10.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-SbT76ETXC5AgV9J8sVDozKG8wzrrxsOn8lbBprlOtx+O5V5EYmS1W7BlsatTHy6ddQ3uU5oOYO04PWZBuP6wXg=="],
+    "@ff-labs/fff-bin-win32-arm64": ["@ff-labs/fff-bin-win32-arm64@0.10.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ztcb6wZwQCgF3h3kKvUaT6+6cYzzjFxTkn28b+0lqi7Yh/HTQVTS4Y0jyf/I9RVrK6sBpvDIliYaDWMRdIAmEw=="],
 
-    "@ff-labs/fff-bin-win32-x64": ["@ff-labs/fff-bin-win32-x64@0.10.1", "", { "os": "win32", "cpu": "x64" }, "sha512-dcpHUCBEZoXKQCdKa3bADfgcNyeyfM8tatXrILqIFYi9GL8E4GnzKx1rGkgP5ukVtuj0WuoJyyqSvGjpJPIT8w=="],
+    "@ff-labs/fff-bin-win32-x64": ["@ff-labs/fff-bin-win32-x64@0.10.3", "", { "os": "win32", "cpu": "x64" }, "sha512-VspB3G0sA2JbJdwgTk5muvMRo2B52grPNa/IMO94tsqUV8C9Dr4iv8Ls4ze8DwywlMaR/Qp1GUrVVpgT3j+JDA=="],
 
-    "@ff-labs/fff-bun": ["@ff-labs/fff-bun@0.10.1", "", { "optionalDependencies": { "@ff-labs/fff-bin-android-arm64": "0.10.1", "@ff-labs/fff-bin-darwin-arm64": "0.10.1", "@ff-labs/fff-bin-darwin-x64": "0.10.1", "@ff-labs/fff-bin-linux-arm64-gnu": "0.10.1", "@ff-labs/fff-bin-linux-arm64-musl": "0.10.1", "@ff-labs/fff-bin-linux-x64-gnu": "0.10.1", "@ff-labs/fff-bin-linux-x64-musl": "0.10.1", "@ff-labs/fff-bin-win32-arm64": "0.10.1", "@ff-labs/fff-bin-win32-x64": "0.10.1" }, "os": [ "!aix", "!sunos", "!freebsd", "!openbsd", ], "cpu": [ "x64", "arm64", ] }, "sha512-9oUCxypGbf2q3vNfKZ31wdzt5KqjhA9S6TwQaFol/j1lkSHVGvtIa3RvdGHPs1UUuvR/MO7b6pHj054BR9bXPQ=="],
+    "@ff-labs/fff-bun": ["@ff-labs/fff-bun@0.10.3", "", { "optionalDependencies": { "@ff-labs/fff-bin-android-arm64": "0.10.3", "@ff-labs/fff-bin-darwin-arm64": "0.10.3", "@ff-labs/fff-bin-darwin-x64": "0.10.3", "@ff-labs/fff-bin-linux-arm64-gnu": "0.10.3", "@ff-labs/fff-bin-linux-arm64-musl": "0.10.3", "@ff-labs/fff-bin-linux-x64-gnu": "0.10.3", "@ff-labs/fff-bin-linux-x64-musl": "0.10.3", "@ff-labs/fff-bin-win32-arm64": "0.10.3", "@ff-labs/fff-bin-win32-x64": "0.10.3" }, "os": [ "!aix", "!sunos", "!freebsd", "!openbsd", ], "cpu": [ "x64", "arm64", ] }, "sha512-KukJ61YeLHvWGgLZQGtAWIkYWhQYVdXcujEioq0UWjjlnSnJvsvm7EMN0JZIDXgG+MOJNii4Ir1+udPxRROf9A=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "1.3.0",
-    "@aws-sdk/client-bedrock": "^3.1097.0",
+    "@aws-sdk/client-bedrock": "^3.1106.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1086.0",
     "@aws-sdk/credential-providers": "^3.1090.0",
     "@ff-labs/fff-bun": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -73,10 +73,10 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "1.3.0",
-    "@aws-sdk/client-bedrock": "^3.1097.0",
+    "@aws-sdk/client-bedrock": "^3.1106.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1086.0",
     "@aws-sdk/credential-providers": "^3.1090.0",
-    "@ff-labs/fff-bun": "0.10.1",
+    "@ff-labs/fff-bun": "0.10.3",
     "chalk": "^5.6.2",
     "commander": "^15.0.0",
     "diff": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@aws-sdk/client-bedrock": "^3.1097.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1086.0",
     "@aws-sdk/credential-providers": "^3.1090.0",
-    "@ff-labs/fff-bun": "0.10.1",
+    "@ff-labs/fff-bun": "0.10.3",
     "chalk": "^5.6.2",
     "commander": "^15.0.0",
     "diff": "^9.0.0",


### PR DESCRIPTION
## What changed

- raise `@aws-sdk/client-bedrock` from `^3.1097.0` to `^3.1106.0`
- update `@ff-labs/fff-bun` and all platform-specific native packages from `0.10.1` to `0.10.3`
- regenerate `bun.lock` so frozen installs remain valid
- preserve the exact branch ancestry for Dependabot PRs #450 and #488

## Why

Both Dependabot PRs changed only `package.json`. Applied directly, they reproduce:

```
error: lockfile had changes, but lockfile is frozen
```

This follow-up lands both updates as one coherent, installable dependency graph.

## Validation

- failing frozen-install state reproduced before lock regeneration
- `bun install --frozen-lockfile`: passed
- focused Bedrock and fff tests: 8 passed
- lint: passed
- TypeScript 7 type check: passed
- full Vitest suite: 555 files passed, 2 skipped; 8,123 tests passed, 26 skipped
- ESM, CJS, and declaration builds: passed
- Tuistory: 5 files passed; 65 tests passed

Integrates #450 and #488.