### PR TITLE
Refresh CLI build toolchains and fix CI regressions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,6 +2,11 @@
 
 This directory contains automated CI/CD workflows for the Autohand CLI project.
 
+CI and release jobs use Node.js 24 and the Bun version declared in the root
+`package.json` (`packageManager`). Update that declaration to change the compiler
+for every build platform together. Frozen installs preserve the committed dependency
+resolutions. Weekly Dependabot updates keep the GitHub Actions versions current.
+
 ## Workflows
 
 ### 🚀 Release (`release.yml`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.22
+          bun-version-file: package.json
 
       - name: Install build tools (Ubuntu)
         if: runner.os == 'Linux'
@@ -45,10 +51,16 @@ jobs:
           # release tag, which they find with `git tag --merged HEAD`.
           fetch-depth: 0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.22
+          bun-version-file: package.json
 
       - name: Install build tools (Ubuntu)
         run: sudo apt-get update && sudo apt-get install -y build-essential python3 make g++
@@ -71,10 +83,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.22
+          bun-version-file: package.json
 
       - name: Install build tools (Ubuntu)
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: bun run test:tuistory
 
   build-test:
-    needs: [test, tuistory]
+    # These jobs build independently, so report platform failures alongside the suites.
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,16 @@ jobs:
             echo "should_release=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.22
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -145,10 +151,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.22
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -170,10 +182,16 @@ jobs:
           # release tag found via `git tag --merged HEAD`.
           fetch-depth: 0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.22
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -210,10 +228,16 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.22
+          bun-version-file: package.json
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -337,8 +361,16 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8

--- a/install.ps1
+++ b/install.ps1
@@ -405,7 +405,7 @@ function Save-UserPathBackup {
     }
 
     $backupPath = Join-Path $BackupDirectory ("user-path-backup-" + (Get-Date).ToString("yyyyMMdd-HHmmss") + ".txt")
-    [System.IO.File]::WriteAllText($backupPath, $Value, [System.Text.Encoding]::UTF8)
+    [System.IO.File]::WriteAllText($backupPath, $Value, [System.Text.UTF8Encoding]::new($false))
     return $backupPath
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -295,7 +295,7 @@ function Get-UpdatedUserPath {
     if (-not [string]::IsNullOrWhiteSpace($CurrentPath)) {
         # Split on semicolons, but respect quoted entries that may contain semicolons.
         # Use a simple regex that handles quoted paths.
-        $entries = [regex]::Split($CurrentPath, '(?<=^[^"]*"(?:[^"]*"[^"]*")*[^"]*$)')
+        $entries = [regex]::Split($CurrentPath, ';(?=(?:[^"]*"[^"]*")*[^"]*$)')
         foreach ($entry in $entries) {
             $normalized = $entry.Trim().Trim('"').TrimEnd('\', '/')
             if ([string]::IsNullOrWhiteSpace($normalized)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "autohand-cli",
   "version": "0.8.2",
+  "packageManager": "bun@1.4.2",
   "license": "Apache-2.0",
   "description": "Autohand Code CLI is a fast, terminal-native AI coding agent for planning, editing, testing, and automating software work.",
   "repository": {

--- a/tests/ci/workflowCheckout.test.ts
+++ b/tests/ci/workflowCheckout.test.ts
@@ -49,6 +49,20 @@ function hasFullHistoryCheckout(job: WorkflowJob): boolean {
  * release workflow kept failing because it runs the same suite from its own job.
  */
 describe('CI workflow checkout', () => {
+  it('uses the declared Bun toolchain in every build and release job', () => {
+    const packageJson: { packageManager?: string } = JSON.parse(
+      readFileSync(path.join(WORKFLOW_DIR, '../../package.json'), 'utf8'),
+    );
+    expect(packageJson.packageManager).toMatch(/^bun@\d+\.\d+\.\d+$/u);
+
+    const bunJobs = readWorkflowJobs().filter((job) => job.body.includes('oven-sh/setup-bun@'));
+    expect(bunJobs.length).toBeGreaterThan(0);
+    for (const job of bunJobs) {
+      expect(job.body, `${job.workflow}:${job.name}`).toMatch(/bun-version-file:\s*package\.json/u);
+      expect(job.body, `${job.workflow}:${job.name}`).not.toMatch(/\bbun-version:/u);
+    }
+  });
+
   it('finds at least one job running the built terminal tests', () => {
     const tuistoryJobs = readWorkflowJobs().filter((job) => job.body.includes('test:tuistory'));
     expect(tuistoryJobs.length).toBeGreaterThan(0);

--- a/tests/sync/integration.test.ts
+++ b/tests/sync/integration.test.ts
@@ -30,11 +30,12 @@ describe("Sync Integration", () => {
 
     // Set up mock for global fetch
     mockFetch = vi.fn();
-    (global as any).fetch = mockFetch;
+    vi.stubGlobal("fetch", mockFetch);
   });
 
   afterEach(async () => {
     await fs.remove(tempDir).catch(() => {});
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 

--- a/tests/tuistory/automatic-specialists.tuistory.test.ts
+++ b/tests/tuistory/automatic-specialists.tuistory.test.ts
@@ -183,7 +183,7 @@ describe('automatic specialist orchestration', () => {
     expect(output).toContain('TEAM_LAUNCH_OK');
     expect(output).not.toContain('Agent not found');
     const providerContext = JSON.stringify(server.requests);
-    expect(providerContext).toContain('Teammate \\"security-reviewer\\" added (agent: security-auditor)');
+    expect(providerContext).toContain('Teammate \\"security-reviewer\\" added (agent: security-auditor; openrouter · openai/gpt-4o-mini)');
     expect(providerContext).toContain('requested: security');
     expect(providerContext).toContain('source: builtin');
   }, 90_000);

--- a/tests/tuistory/built-cli.tuistory.test.ts
+++ b/tests/tuistory/built-cli.tuistory.test.ts
@@ -1430,7 +1430,7 @@ describe('interactive built CLI Tuistory tests', () => {
     expect(promptRow).toBeGreaterThan(0);
     expect(screenLines[promptRow - 1]).toContain('▔');
     expect(screenLines[promptRow + 1]).toContain('▁');
-    expect(screenLines[promptRow + 2]).toContain('autohand (');
+    expect(screenLines[promptRow + 2]).toContain('Autohand (');
 
     await exitInteractive(session);
   });
@@ -1968,14 +1968,14 @@ describe('interactive built CLI Tuistory tests', () => {
       timeout: 10_000,
       waitFor: (text) => (
         text.includes('❯') &&
-        text.includes('autohand (') &&
+        text.includes('Autohand (') &&
         !text.includes('Wandering')
       ),
       trimEnd: true,
     });
 
     expect(linesContaining(screen, '❯'), screen).toHaveLength(1);
-    expect(linesContaining(screen, 'autohand ('), screen).toHaveLength(1);
+    expect(linesContaining(screen, 'Autohand ('), screen).toHaveLength(1);
     expect(screen).not.toContain('Wandering');
 
     await exitInteractive(session);
@@ -2993,11 +2993,11 @@ describe('interactive built CLI Tuistory tests', () => {
     await session.waitForText(`Using ollama model ${selectedModel}`, { timeout: 10_000 });
     await session.text({
       timeout: 10_000,
-      waitFor: (text) => text.includes(`autohand (Ollama, ${selectedModel})`),
+      waitFor: (text) => text.includes(`Autohand (Pro) (Ollama, ${selectedModel})`),
     });
 
     const screen = await session.text({ trimEnd: true });
-    expect(screen).toContain(`autohand (Ollama, ${selectedModel})`);
+    expect(screen).toContain(`Autohand (Pro) (Ollama, ${selectedModel})`);
 
     await exitInteractive(session);
 
@@ -3012,10 +3012,10 @@ describe('interactive built CLI Tuistory tests', () => {
     await waitForComposer(restartedSession);
     const restartedScreen = await restartedSession.text({
       timeout: 10_000,
-      waitFor: (text) => text.includes(`autohand (Ollama, ${selectedModel})`),
+      waitFor: (text) => text.includes(`Autohand (Pro) (Ollama, ${selectedModel})`),
       trimEnd: true,
     });
-    expect(restartedScreen).toContain(`autohand (Ollama, ${selectedModel})`);
+    expect(restartedScreen).toContain(`Autohand (Pro) (Ollama, ${selectedModel})`);
     await exitInteractive(restartedSession);
   });
 
@@ -3059,10 +3059,10 @@ describe('interactive built CLI Tuistory tests', () => {
     await session.waitForText('Anthropic configured successfully!', { timeout: 10_000 });
     const screen = await session.text({
       timeout: 10_000,
-      waitFor: (text) => text.includes(`autohand (Anthropic, ${selectedModel})`),
+      waitFor: (text) => text.includes(`Autohand (Pro) (Anthropic, ${selectedModel})`),
       trimEnd: true,
     });
-    expect(screen).toContain(`autohand (Anthropic, ${selectedModel})`);
+    expect(screen).toContain(`Autohand (Pro) (Anthropic, ${selectedModel})`);
 
     await exitInteractive(session);
 
@@ -3080,10 +3080,10 @@ describe('interactive built CLI Tuistory tests', () => {
     await waitForComposer(restartedSession);
     const restartedScreen = await restartedSession.text({
       timeout: 10_000,
-      waitFor: (text) => text.includes(`autohand (Anthropic, ${selectedModel})`),
+      waitFor: (text) => text.includes(`Autohand (Pro) (Anthropic, ${selectedModel})`),
       trimEnd: true,
     });
-    expect(restartedScreen).toContain(`autohand (Anthropic, ${selectedModel})`);
+    expect(restartedScreen).toContain(`Autohand (Pro) (Anthropic, ${selectedModel})`);
     await exitInteractive(restartedSession);
   });
 
@@ -3140,11 +3140,11 @@ describe('interactive built CLI Tuistory tests', () => {
     await session.waitForText('Autohand AI configured successfully!', { timeout: 10_000 });
     await session.text({
       timeout: 10_000,
-      waitFor: (text) => text.includes(`autohand (Autohand AI, ${selectedModel})`),
+      waitFor: (text) => text.includes(`Autohand (Pro) (Autohand AI, ${selectedModel})`),
     });
 
     const screen = await session.text({ trimEnd: true });
-    expect(screen).toContain(`autohand (Autohand AI, ${selectedModel})`);
+    expect(screen).toContain(`Autohand (Pro) (Autohand AI, ${selectedModel})`);
 
     await exitInteractive(session);
 
@@ -3159,10 +3159,10 @@ describe('interactive built CLI Tuistory tests', () => {
     await waitForComposer(restartedSession);
     const restartedScreen = await restartedSession.text({
       timeout: 10_000,
-      waitFor: (text) => text.includes(`autohand (Autohand AI, ${selectedModel})`),
+      waitFor: (text) => text.includes(`Autohand (Pro) (Autohand AI, ${selectedModel})`),
       trimEnd: true,
     });
-    expect(restartedScreen).toContain(`autohand (Autohand AI, ${selectedModel})`);
+    expect(restartedScreen).toContain(`Autohand (Pro) (Autohand AI, ${selectedModel})`);
     await exitInteractive(restartedSession);
   });
 });

--- a/tests/windowsInstaller.spec.ts
+++ b/tests/windowsInstaller.spec.ts
@@ -299,11 +299,30 @@ ${probes}
     });
   });
 
+  powerShellTest('backs up the exact PATH text without an encoding prefix', () => {
+    const backupDirectory = mkdtempSync(join(tmpdir(), 'autohand-path-backup-text-'));
+    const seeded = '%LOCALAPPDATA%\\Microsoft\\WindowsApps;C:\\tools\\restic';
+    try {
+      const result = runPowerShellProbe(`${installerWithoutEntrypoint}
+Write-Output (Save-UserPathBackup -Value '${seeded}' -BackupDirectory '${backupDirectory}')
+`);
+      expect(result.stderr).toBe('');
+      expect(result.status).toBe(0);
+      expect(readFileSync(result.stdout.trim(), 'utf8')).toBe(seeded);
+    } finally {
+      rmSync(backupDirectory, { recursive: true, force: true });
+    }
+  });
+
   powerShellTest('fails closed without writing when the existing PATH cannot be read', () => {
-    // A read failure must never be mistaken for "PATH is empty" - that is precisely how a
-    // wipe happens. Off-Windows the registry API throws, which exercises the same branch.
+    // A missing key is a valid empty PATH on Windows. Simulate an actual read
+    // failure explicitly so every platform exercises the fail-closed branch.
     const result = runPowerShellProbe(`${installerWithoutEntrypoint}
 $script:writeAttempts = 0
+function Get-RawUserPath {
+    param($SubKeyName)
+    throw "fixture registry read failure"
+}
 function Set-RawUserPath {
     param($Value, $Kind, $SubKeyName)
     $script:writeAttempts++

--- a/tests/windowsInstaller.spec.ts
+++ b/tests/windowsInstaller.spec.ts
@@ -201,11 +201,13 @@ Write-Output (Probe -Current 'C:\\a;${install};C:\\b' -Install '${install}')
 Write-Output (Probe -Current 'C:\\a;c:\\users\\dev\\appdata\\local\\AUTOHAND\\;C:\\b' -Install '${install}')
 Write-Output (Probe -Current 'C:\\a;"${install}";C:\\b' -Install '${install}')
 Write-Output (Probe -Current 'C:\\a; ${install} ;C:\\b' -Install '${install}')
+Write-Output (Probe -Current 'C:\\a;"C:\\tools;team\\autohand";C:\\b' -Install 'C:\\tools;team\\autohand')
 `);
 
     expect(result.stderr).toBe('');
     expect(result.status).toBe(0);
     expect(result.stdout.trim().split(/\r?\n/u)).toEqual([
+      '<unchanged>',
       '<unchanged>',
       '<unchanged>',
       '<unchanged>',


### PR DESCRIPTION
Build and release jobs currently pin Bun 1.2.22 independently, and one publication job uses an unpinned version. Declare Bun 1.4.2 once in package.json and have every CI/release job read it. Set Node.js 24 explicitly using setup-node v7, retain frozen installs, and add a regression check that prevents independent Bun pins from returning.

Full validation exposed test cleanup and stale terminal expectations. Restore mocked fetch after sync tests so subsequent WASM imports work, and align terminal assertions with the existing capitalized Autohand/Pro status line and teammate provider/model output.

The Windows installer also failed to split PATH entries, appending a duplicate install directory even when it was present. Split only on semicolons outside quotes and cover quoted paths containing semicolons; preserve the original PATH verbatim whenever an append is needed.

Write PATH backups with explicit UTF-8 without a byte-order mark so their text round-trips exactly across PowerShell versions. Simulate registry read failure explicitly in the fail-closed test instead of relying on platform behavior. Run independent platform builds alongside unit and terminal suites so CI reports all failures in one pass.

Validation: `CI=true bun run proof` passes on the final commit with Node 24.20.0/Bun 1.4.2: 8,588 unit tests, build, and all 91 terminal tests. Lint reports four existing warnings and no errors. All edited workflows pass actionlint 1.7.12. Both hosted CI runs pass unit and terminal suites plus macOS/Linux/Windows compilation and executable smoke checks, including Windows installer architecture and registry tests.

[Final pull-request CI](https://github.com/autohandai/code-cli/actions/runs/34183586805)
