### PR TITLE
Refresh payment access and move suspended Cloud sessions to Free

### DIFF
--- a/src/auth/AuthClient.ts
+++ b/src/auth/AuthClient.ts
@@ -53,7 +53,29 @@ export interface AccountQuota {
   message?: string;
 }
 
+export interface PaymentAccessNotice {
+  status: 'suspended';
+  reason: 'stripe_blocked';
+  effectiveTier: 'free';
+  planName: string;
+  since: string;
+  message: string;
+  actionUrl: string;
+}
+
+function parsePaymentAccess(value: unknown): PaymentAccessNotice | undefined {
+  if (!isRecord(value) || value.status !== 'suspended' || value.reason !== 'stripe_blocked'
+    || value.effectiveTier !== 'free' || !isSafeText(value.planName)
+    || !isSafeText(value.since) || !isSafeText(value.message, 2000) || !isSafeText(value.actionUrl, 1000)) return undefined;
+  try {
+    const url = new URL(value.actionUrl);
+    if (url.origin !== 'https://console.autohand.ai' || url.pathname !== '/billing') return undefined;
+  } catch { return undefined; }
+  return { status: 'suspended', reason: 'stripe_blocked', effectiveTier: 'free', planName: value.planName, since: value.since, message: value.message, actionUrl: value.actionUrl };
+}
+
 export interface AccountEntitlement {
+  paymentAccess?: PaymentAccessNotice;
   tier: string;
   accountName?: string;
   freeRemaining: number | null;
@@ -602,6 +624,7 @@ export class AuthClient {
       const directAccountName = isSafeText(entitlement?.accountName) ? entitlement.accountName.trim() : undefined;
       const accountName = directAccountName
         ?? (tier === 'team' ? await this.fetchActiveAccountName(token) : undefined);
+      const paymentAccess = parsePaymentAccess(entitlement?.paymentAccess);
       const freeRemaining = entitlement?.freeRemaining;
       const limits = parseAccountEntitlementLimits(entitlement?.limits);
       const quota = parseAccountQuota(entitlement?.quota);
@@ -611,6 +634,7 @@ export class AuthClient {
       return {
         tier,
         ...(accountName ? { accountName } : {}),
+        ...(paymentAccess ? { paymentAccess } : {}),
         freeRemaining: typeof freeRemaining === 'number' ? freeRemaining : null,
         // Omitted rather than null when unknown, matching the other optional fields.
         ...(cycle ? { interval: cycle } : {}),

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -9,6 +9,7 @@ import os from 'node:os';
 import { showModal, type ModalOption } from '../ui/ink/components/Modal.js';
 import { FileActionManager } from '../actions/filesystem.js';
 import { getProviderConfig, saveConfig } from '../config.js';
+import { resolveAutohandAIModelForTier } from './agent/AutohandAIModelTierPolicy.js';
 import { getAuthClient } from '../auth/index.js';
 import {
   formatComposerPlanLabel,
@@ -17,7 +18,7 @@ import {
 } from '../billing/planSummary.js';
 
 /** Slow on purpose: the plan changes rarely and this must not add load. */
-const ACCOUNT_PLAN_REFRESH_MS = 5 * 60 * 1000;
+const ACCOUNT_PLAN_REFRESH_MS = 30_000;
 import { safePrompt } from '../utils/prompt.js';
 import { maybeOfferAutohandAISwitch } from '../commands/login.js';
 import { getFeatureState, isAwsBedrockProviderEnabled } from '../features/featureRegistry.js';
@@ -418,6 +419,8 @@ export class AutohandAgent {
   private sessionDiffStatsTracker?: SessionDiffStatsTracker;
   /** Account plan shown on the status line; refreshed so upgrades appear mid-session. */
   private accountPlan: PlanSummary | null = null;
+  private lastPaymentNotice: string | null = null;
+  private accountPlanRefresh?: Promise<void>;
   private accountPlanTimer?: ReturnType<typeof setInterval>;
   private activeAgentHeartbeat: ActiveAgentHeartbeat | null = null;
   private readonly peerAwareness: PeerAwarenessManager;
@@ -980,6 +983,7 @@ export class AutohandAgent {
   }
 
   async runInstruction(instruction: string, options?: RunInstructionOptions): Promise<boolean> {
+    await this.refreshAccountPlan();
     this.currentInstructionText = instruction;
     try {
       return await this.runInstructionWithPeerActivity(instruction, options);
@@ -1468,15 +1472,24 @@ export class AutohandAgent {
   }
 
   /**
-   * Sync the active provider and model into the Ink status line.
+   * Refresh the plan and payment notice without requiring a restart. At an idle
+   * instruction boundary, align the Cloud model with current access. Failed
+   * refreshes retain the last known display; the API enforces each request.
    */
-  /**
-   * Re-read the account plan and put it back on the status line. Runs at startup and
-   * on a slow timer, so an upgrade made in the console shows up without a restart.
-   * Never throws: the plan is decoration, not something worth interrupting a session for.
-   */
-  private async refreshAccountPlan(): Promise<void> {
-    const token = this.runtime.config.auth?.token;
+  private refreshAccountPlan(): Promise<void> {
+    if (this.accountPlanRefresh) return this.accountPlanRefresh;
+    const pending = this.readAccountPlan().finally(() => { this.accountPlanRefresh = undefined; });
+    this.accountPlanRefresh = pending;
+    return pending;
+  }
+
+  private async readAccountPlan(): Promise<void> {
+    const currentToken = () => this.activeProvider === 'autohandai' && this.runtime.config.autohandai?.plan === 'cloud'
+      ? (this.runtime.config.autohandai.authMode === 'account'
+          ? this.runtime.config.autohandai.accountToken ?? this.runtime.config.auth?.token
+          : this.runtime.config.autohandai.apiKey ?? this.runtime.config.auth?.token)
+      : this.runtime.config.auth?.token;
+    const token = currentToken();
     if (!token) {
       this.accountPlan = null;
       return;
@@ -1484,7 +1497,23 @@ export class AutohandAgent {
 
     try {
       const entitlement = await getAuthClient().fetchEntitlement(token);
+      if (!entitlement || token !== currentToken()) return;
       const next = planSummaryFromEntitlement(entitlement);
+      const payment = entitlement.paymentAccess;
+      const noticeId = payment ? `${payment.actionUrl}:${payment.since}` : null;
+      if (payment && noticeId !== this.lastPaymentNotice) {
+        const content = `${payment.message}\nManage billing: ${payment.actionUrl}`;
+        this.emitOutput({ type: 'message', content });
+        if (!this.runtime.isRpcMode) this.notifyUser(content);
+      }
+      this.lastPaymentNotice = noticeId;
+      const settings = this.runtime.config.autohandai;
+      const model = this.runtime.options.model ?? settings?.model;
+      const resolvedModel = resolveAutohandAIModelForTier({ provider: this.activeProvider, plan: settings?.plan, model, tier: entitlement.tier });
+      if (!this.isInstructionActive && model && resolvedModel !== model && this.providerConfigManager) {
+        if (settings) delete settings.reasoningEffort;
+        await this.providerConfigManager.applyModelChangeRemote('autohandai', resolvedModel);
+      }
       const changed =
         next?.tier !== this.accountPlan?.tier ||
         next?.interval !== this.accountPlan?.interval ||

--- a/src/core/agent/ProviderConfigManager.ts
+++ b/src/core/agent/ProviderConfigManager.ts
@@ -3979,7 +3979,7 @@ export class ProviderConfigManager {
       !newModel ||
       (newModel === currentModel && provider === this.getActiveProvider())
     ) {
-      console.log(chalk.gray(t("providers.config.modelUnchanged")));
+      if (!this.runtime.isRpcMode) console.log(chalk.gray(t("providers.config.modelUnchanged")));
       return;
     }
 
@@ -4002,7 +4002,7 @@ export class ProviderConfigManager {
       ...this.getProviderTelemetryMetadata(provider, newModel, contextWindow),
     });
 
-    console.log(
+    if (!this.runtime.isRpcMode) console.log(
       chalk.green(
         "✓ " + t("providers.config.usingModel", { provider, model: newModel }),
       ),

--- a/src/testing/scenarios/paymentAccessScenario.ts
+++ b/src/testing/scenarios/paymentAccessScenario.ts
@@ -1,0 +1,8 @@
+import type { Session } from 'tuistory';
+
+export async function sendPaymentTransitionTurn(session: Session, prompt: string, response: string) {
+  await session.waitForText('❯', { timeout: 20_000 });
+  await session.type(prompt);
+  await session.press('enter');
+  await session.waitForText(response, { timeout: 30_000 });
+}

--- a/tests/core/agent/PaymentAccessRefresh.test.ts
+++ b/tests/core/agent/PaymentAccessRefresh.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AutohandAgent } from '../../../src/core/agent.js';
+import { getAuthClient } from '../../../src/auth/index.js';
+
+const paymentAccess = { status: 'suspended', reason: 'stripe_blocked', effectiveTier: 'free', planName: 'Autohand Code Pro', since: '2026-09-08T00:00:00Z', message: 'Stripe blocked your payment. Your paid plan is suspended and your account is now on Free.', actionUrl: 'https://console.autohand.ai/billing?account=personal_1' } as const;
+function agent() {
+  return Object.assign(Object.create(AutohandAgent.prototype), {
+    activeProvider: 'autohandai', isInstructionActive: false,
+    runtime: { config: { auth: { token: 'fixture' }, provider: 'autohandai', autohandai: { plan: 'cloud', model: 'moa', reasoningEffort: 'high' } }, options: { model: 'moa' } },
+    accountPlan: { tier: 'pro', label: 'Pro', interval: 'month' },
+    syncProviderModelStatusLine: vi.fn(), emitOutput: vi.fn(), notifyUser: vi.fn(),
+    providerConfigManager: { applyModelChangeRemote: vi.fn().mockResolvedValue({ status: 'applied', model: 'fantail', provider: 'autohandai' }) },
+  });
+}
+afterEach(() => vi.restoreAllMocks());
+describe('live payment access refresh', () => {
+  it('automatically selects Fantail, displays Free and emits a single recovery notice', async () => {
+    vi.spyOn(getAuthClient(), 'fetchEntitlement').mockResolvedValue({ tier: 'free', freeRemaining: 20, paymentAccess });
+    const host = agent();
+    await host.refreshAccountPlan();
+    expect(host.accountPlan.tier).toBe('free');
+    expect(host.providerConfigManager.applyModelChangeRemote).toHaveBeenCalledWith('autohandai', 'fantail');
+    expect(host.emitOutput).toHaveBeenCalledWith(expect.objectContaining({ content: expect.stringContaining('Stripe blocked your payment') }));
+    await host.refreshAccountPlan();
+    expect(host.emitOutput).toHaveBeenCalledTimes(1);
+    expect(host.runtime.config.autohandai.reasoningEffort).toBeUndefined();
+  });
+  it('preserves third-party and local provider selections and the last plan during outages', async () => {
+    const host = agent(); host.activeProvider = 'openai'; host.runtime.config.provider = 'openai';
+    const fetch = vi.spyOn(getAuthClient(), 'fetchEntitlement').mockResolvedValue({ tier: 'free', freeRemaining: 20, paymentAccess });
+    await host.refreshAccountPlan();
+    expect(host.providerConfigManager.applyModelChangeRemote).not.toHaveBeenCalled();
+    fetch.mockResolvedValue(null);
+    await host.refreshAccountPlan();
+    expect(host.accountPlan.tier).toBe('free');
+  });
+  it('defers provider replacement during an active turn', async () => {
+    vi.spyOn(getAuthClient(), 'fetchEntitlement').mockResolvedValue({ tier: 'free', freeRemaining: 20, paymentAccess });
+    const host = agent(); host.isInstructionActive = true;
+    await host.refreshAccountPlan();
+    expect(host.providerConfigManager.applyModelChangeRemote).not.toHaveBeenCalled();
+  });
+  it('reads the account selected by the active provider API key', async () => {
+    const fetch = vi.spyOn(getAuthClient(), 'fetchEntitlement').mockResolvedValue({ tier: 'free', freeRemaining: 20, paymentAccess });
+    const host = agent();
+    host.runtime.config.autohandai.apiKey = 'ahk_team_fixture';
+    await host.refreshAccountPlan();
+    expect(fetch).toHaveBeenCalledWith('ahk_team_fixture');
+    expect(host.accountPlan.tier).toBe('free');
+  });
+});

--- a/tests/mobile/AgentMobileTurnLifecycle.test.ts
+++ b/tests/mobile/AgentMobileTurnLifecycle.test.ts
@@ -13,6 +13,7 @@ function installMobileSessionBoundaryFixtures(agent: any): void {
     config: { configPath: '/tmp/autohand-test-config.json' },
   };
   agent.activeProvider ??= 'openrouter';
+  agent.refreshAccountPlan = vi.fn().mockResolvedValue(undefined);
   agent.sessionStartedAt ??= Date.now();
   agent.hookManager ??= { executeHooks: vi.fn().mockResolvedValue([]) };
   agent.telemetryManager ??= {

--- a/tests/tuistory/helpers/autohandTuistory.ts
+++ b/tests/tuistory/helpers/autohandTuistory.ts
@@ -77,6 +77,7 @@ export interface MockAuthServer {
 }
 
 export interface MockAuthServerOptions {
+  paymentBlocked?: () => boolean;
   authorizeAfterPolls?: number;
   deviceAuthSchemaVersion?: 1 | 2;
 }
@@ -942,7 +943,10 @@ export async function createMockAuthServer(
           email: 'tuistory@example.com',
           name: 'Tuistory Test',
         },
-        entitlement: {
+        entitlement: options.paymentBlocked?.() ? {
+          tier: 'free', freeRemaining: 20,
+          paymentAccess: { status: 'suspended', reason: 'stripe_blocked', effectiveTier: 'free', planName: 'Autohand Code Pro', since: '2026-09-08T00:00:00Z', message: 'Stripe blocked your payment. Your paid plan is suspended and your account is now on Free.', actionUrl: 'https://console.autohand.ai/billing?account=personal_tuistory' },
+        } : {
           tier: 'pro',
           freeRemaining: null,
           limits: {

--- a/tests/tuistory/payment-access.tuistory.test.ts
+++ b/tests/tuistory/payment-access.tuistory.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import type { Session } from 'tuistory';
+import { sendPaymentTransitionTurn } from '../../src/testing/scenarios/paymentAccessScenario.js';
+import { createMockAuthServer, createMockAutohandAINativeSequenceServer, createTempAutohandHome, exitInteractive, launchBuiltAutohand, type MockAuthServer, type MockNativeToolServer, type TuistoryTempState } from './helpers/autohandTuistory.js';
+let session: Session | undefined;
+let auth: MockAuthServer | undefined;
+let server: MockNativeToolServer | undefined;
+let state: TuistoryTempState | undefined;
+afterEach(async () => { session?.close(); await auth?.close(); await server?.close(); await state?.cleanup(); });
+describe('Stripe suspension in an open CLI', () => {
+  it('notifies once, changes the composer to Free, and uses Fantail on the next turn without restarting', async () => {
+    let blocked = false;
+    auth = await createMockAuthServer({ paymentBlocked: () => blocked });
+    server = await createMockAutohandAINativeSequenceServer([{ content: 'PAID_TURN_DONE' }, { content: 'FREE_TURN_DONE' }, { content: 'FREE_STILL_WORKS' }]);
+    state = await createTempAutohandHome({ config: {
+      provider: 'autohandai',
+      auth: { token: 'tuistory-account-token', user: { id: 'tuistory-test-user', email: 'tuistory@example.com', name: 'Tuistory Test' } },
+      autohandai: { plan: 'cloud', authMode: 'account', accountToken: 'tuistory-account-token', model: 'moa', baseUrl: server.baseUrl, reasoningEffort: 'high' },
+      agent: { autoMemory: false }, ui: { promptSuggestions: false, showCompletionNotification: false, terminalBell: false },
+    } });
+    session = await launchBuiltAutohand(['--path', state.workspaceRoot, '--config', state.configPath, '--y'], { autohandHome: state.autohandHome, cwd: state.workspaceRoot, env: { AUTOHAND_AUTH_API_URL: `${auth.baseUrl}/api/auth` } });
+    await sendPaymentTransitionTurn(session, 'Say the paid marker', 'PAID_TURN_DONE');
+    blocked = true;
+    await sendPaymentTransitionTurn(session, 'Continue on the available plan', 'FREE_TURN_DONE');
+    await session.waitForText('Free');
+    expect(session.readAll()).toContain('Stripe blocked your payment');
+    expect(session.readAll()).toContain('Manage billing: https://console.autohand.ai/billing');
+    expect(server.requests[0]?.model).toBe('moa');
+    expect(server.requests[1]?.model).toBe('fantail');
+    const config = JSON.parse(await readFile(state.configPath, 'utf8'));
+    expect(config.autohandai.model).toBe('fantail');
+    expect(config.autohandai.reasoningEffort).toBeUndefined();
+    await sendPaymentTransitionTurn(session, 'Continue once more', 'FREE_STILL_WORKS');
+    expect(server.requests[2]?.model).toBe('fantail');
+    await exitInteractive(session);
+  });
+});


### PR DESCRIPTION
Stripe-confirmed payment holds now refresh in running CLI sessions. Autohand Cloud switches an idle paid-model session to persisted Fantail/Free and shows account-scoped billing recovery guidance. Refresh runs at startup, before instructions, and every 30 seconds; other providers keep their selections.

Validation on current main plus this commit, with Bun 1.4.2: `bun run proof` passed, including lint, typecheck, 8,585 unit tests, build, and 92 real-terminal tests. Coverage includes account credential changes, active turns, provider isolation, and the built payment-access downgrade flow.
