### PR TITLE
Ask the terminal to encode modified keys so Shift+Enter inserts a newline in iTerm2

### DIFF
--- a/src/ui/ink/InkRenderer.tsx
+++ b/src/ui/ink/InkRenderer.tsx
@@ -10,6 +10,7 @@
  * instead of calling instance.rerender() on every state change. This eliminates
  * flickering by letting React handle efficient DOM updates.
  */
+import { disableKittyProtocol, enableKittyProtocol, KITTY_DISAMBIGUATE_FLAG } from '../kittyProtocol.js';
 import React, { useState, useImperativeHandle, forwardRef, useCallback, useRef } from 'react';
 import { render, type Instance } from 'ink';
 import {
@@ -454,6 +455,13 @@ export class InkRenderer {
     // frame updates. Must happen before Ink starts writing to stdout.
     this.unpatchedStdout = patchStdoutForSyncOutput();
 
+    // Shift+Enter, Alt+Enter and Esc are only distinguishable when the
+    // terminal encodes modified keys. Ink parses the kitty CSI u form; iTerm2,
+    // Ghostty, kitty and WezTerm honour the request, others ignore it.
+    if (process.stdout.isTTY) {
+      enableKittyProtocol(process.stdout, KITTY_DISAMBIGUATE_FLAG);
+    }
+
     // Install our resize guard BEFORE Ink registers its own handler.
     // Node.js event listeners fire in registration order.
     this.resizeHandler = this.onResize;
@@ -513,6 +521,9 @@ export class InkRenderer {
    * Stop the Ink renderer and cleanup
    */
   stop(): void {
+    if (this.instance && process.stdout.isTTY) {
+      disableKittyProtocol(process.stdout);
+    }
     if (this.instance) {
       const instance = this.instance;
       try {

--- a/src/ui/kittyProtocol.ts
+++ b/src/ui/kittyProtocol.ts
@@ -63,6 +63,13 @@ export function queryKittyProtocol(stdout: NodeJS.WriteStream): void {
 }
 
 /**
+ * Flag 1 only: modified keys that have no legacy encoding (Shift+Enter,
+ * Alt+key, Esc) arrive as CSI u while plain keys and Ctrl+letters keep their
+ * legacy bytes. Terminals without the protocol ignore the request.
+ */
+export const KITTY_DISAMBIGUATE_FLAG = 1;
+
+/**
  * Enable Kitty keyboard protocol with specified flags.
  *
  * Flags (bitmask):

--- a/tests/tuistory/built-cli.tuistory.test.ts
+++ b/tests/tuistory/built-cli.tuistory.test.ts
@@ -1818,6 +1818,9 @@ describe('interactive built CLI Tuistory tests', () => {
     });
 
     await waitForComposer(session);
+    // Shift+Enter is only distinguishable from Enter once the terminal encodes
+    // modified keys; the composer asks for the kitty disambiguate flag on start.
+    expect(session.getRawOutput()).toContain('\u001b[>1u');
     await session.type('first line');
     await session.press(['shift', 'enter']);
     await session.type('second line');
@@ -1861,6 +1864,8 @@ describe('interactive built CLI Tuistory tests', () => {
     expect(imagePasteScreen).toMatch(/\[Image #\d+\]/);
 
     await exitInteractive(session);
+    const rawOutput = session.getRawOutput();
+    expect(rawOutput.lastIndexOf('\u001b[<u')).toBeGreaterThan(rawOutput.indexOf('\u001b[>1u'));
   });
 
   it('auto-initializes git for an empty workspace before rendering the composer', async () => {

--- a/tests/ui/ink/InkRenderer.pause-resume.test.ts
+++ b/tests/ui/ink/InkRenderer.pause-resume.test.ts
@@ -61,6 +61,59 @@ function lastRenderedTaskListPositionProvider(): (() => unknown) | undefined {
   return root?.props.children.props.children.props.taskListPositionProvider;
 }
 
+describe('InkRenderer keyboard protocol lifecycle', () => {
+  it('pushes the kitty disambiguate flag when the UI starts and pops it when it stops', () => {
+    const originalIsTTY = process.stdout.isTTY;
+    (process.stdout as any).isTTY = true;
+    const writes: string[] = [];
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    const renderer = new InkRenderer({
+      onInstruction: () => {},
+      onEscape: () => {},
+      onCtrlC: () => {},
+    });
+    try {
+      renderer.start();
+      expect(writes).toContain('\x1b[>1u');
+      expect(writes).not.toContain('\x1b[<u');
+
+      renderer.stop();
+      expect(writes.lastIndexOf('\x1b[<u')).toBeGreaterThan(writes.indexOf('\x1b[>1u'));
+    } finally {
+      renderer.stop();
+      write.mockRestore();
+      (process.stdout as any).isTTY = originalIsTTY;
+    }
+  });
+
+  it('leaves a non-terminal stdout alone', () => {
+    const originalIsTTY = process.stdout.isTTY;
+    (process.stdout as any).isTTY = false;
+    const writes: string[] = [];
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    const renderer = new InkRenderer({
+      onInstruction: () => {},
+      onEscape: () => {},
+      onCtrlC: () => {},
+    });
+    try {
+      renderer.start();
+      renderer.stop();
+      expect(writes.join('')).not.toContain('\x1b[>1u');
+      expect(writes.join('')).not.toContain('\x1b[<u');
+    } finally {
+      write.mockRestore();
+      (process.stdout as any).isTTY = originalIsTTY;
+    }
+  });
+});
+
 describe('InkRenderer pause/resume cycle', () => {
   let renderer: InkRenderer;
   let originalIsTTY: boolean | undefined;


### PR DESCRIPTION
## Why

Shift+Enter submitted the message instead of inserting a newline in iTerm2.

The composer already accepts every encoded form of a shifted Enter, and Ink 7 parses the kitty CSI u form natively. What was missing is the handshake: nothing in the Ink runtime asked the terminal to encode modified keys (`ProcessTerminal`, the only code that does, has no callers). kitty and Ghostty send CSI u for Shift+Enter unprompted, and the Tuistory harness encodes it the same way, which is why the shortcut worked there. iTerm2 sends a plain carriage return unless asked.

## What changed

- `InkRenderer.start()` pushes the kitty keyboard protocol disambiguate flag (`CSI > 1 u`) on a TTY; `stop()` pops it (`CSI < u`).
- `kittyProtocol.ts` gains a named `KITTY_DISAMBIGUATE_FLAG`.

Flag 1 only changes keys that have no legacy encoding (Shift+Enter, Alt+key, Esc). Plain keys keep their bytes. Terminals without the protocol ignore the request. iTerm2 supports the kitty protocol at runtime; its older CSI u mode is profile-only and deprecated, and `modifyOtherKeys` mode 2 would also re-encode Ctrl+letters, so neither was used.

## Verification

- Unit: renderer pushes on start and pops on stop on a TTY, and leaves a non-TTY stdout alone.
- Tuistory: the multiline built-CLI test asserts the push after the composer appears and the pop after exit.
- Pseudo-terminal run of the built CLI with kitty-encoded keys: Shift+Tab cycles to `[PLAN]`, Shift+Enter inserts a newline, Ctrl+C clears the draft, double Ctrl+C exits with the flag popped.
- eslint and typecheck clean; caret, plan-startup, cycle and refresh Tuistory tests still pass.

Not covered: Terminal.app has no key-encoding protocol, so Shift+Enter there still needs a key mapping; Alt+Enter works.